### PR TITLE
Fix incorrect sizes for plane and data slices for audio frames.

### DIFF
--- a/src/util/frame/audio.rs
+++ b/src/util/frame/audio.rs
@@ -144,7 +144,18 @@ impl Audio {
             panic!("unsupported type");
         }
 
-        unsafe { slice::from_raw_parts((*self.as_ptr()).data[index] as *const T, self.samples()) }
+        if self.is_planar() {
+            unsafe {
+                slice::from_raw_parts((*self.as_ptr()).data[index] as *const T, self.samples())
+            }
+        } else {
+            unsafe {
+                slice::from_raw_parts(
+                    (*self.as_ptr()).data[0] as *const T,
+                    self.samples() * usize::from(self.channels()),
+                )
+            }
+        }
     }
 
     #[inline]
@@ -157,8 +168,20 @@ impl Audio {
             panic!("unsupported type");
         }
 
-        unsafe {
-            slice::from_raw_parts_mut((*self.as_mut_ptr()).data[index] as *mut T, self.samples())
+        if self.is_planar() {
+            unsafe {
+                slice::from_raw_parts_mut(
+                    (*self.as_mut_ptr()).data[index] as *mut T,
+                    self.samples(),
+                )
+            }
+        } else {
+            unsafe {
+                slice::from_raw_parts_mut(
+                    (*self.as_mut_ptr()).data[0] as *mut T,
+                    self.samples() * usize::from(self.channels()),
+                )
+            }
         }
     }
 
@@ -171,7 +194,7 @@ impl Audio {
         unsafe {
             slice::from_raw_parts(
                 (*self.as_ptr()).data[index],
-                (*self.as_ptr()).linesize[index] as usize,
+                (*self.as_ptr()).linesize[0] as usize,
             )
         }
     }
@@ -185,7 +208,7 @@ impl Audio {
         unsafe {
             slice::from_raw_parts_mut(
                 (*self.as_mut_ptr()).data[index],
-                (*self.as_ptr()).linesize[index] as usize,
+                (*self.as_ptr()).linesize[0] as usize,
             )
         }
     }


### PR DESCRIPTION
Merging upstream https://github.com/zmwangx/rust-ffmpeg/pull/104 PR from @tage64 