### PR TITLE
Fix build instruction link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pull requests are welcome. This is originally a fork of [rust-ffmpeg](https://gi
 
 Currently supported FFmpeg versions: 4.0 through 5.1
 
-Build instructions can be found on the [wiki](https://github.com/flavioroth/rust-ffmpeg/wiki/Notes-on-building).
+Build instructions can be found on the [wiki](https://github.com/zmwangx/rust-ffmpeg/wiki/Notes-on-building).
 
 Documentation:
 - [docs.rs](https://docs.rs/ffmpeg-rs/);


### PR DESCRIPTION
by pointing to the upstream wiki.

Alternately, given the wiki consists of just the one page of build instructions last touched by anyone in 2020, might make more sense to clone https://github.com/zmwangx/rust-ffmpeg.wiki.git and pull it in as a BUILDING.md, or even transclude it directly into this readme.